### PR TITLE
Add symlink for store ssh keys in settings folder /var/local/webvirtmgr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN chown www-data:www-data -R /var/local/webvirtmgr
 
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 RUN ln -s /etc/nginx/sites-available/webvirtmgr /etc/nginx/sites-enabled
+RUN ln -s /var/local/webvirtmgr /var/www
 RUN apt-get -ys clean
 
 WORKDIR /


### PR DESCRIPTION
For new version of webvirtmgr SSH keys stored in /var/www folder (home dir of nginx)
https://github.com/retspen/webvirtmgr/wiki/Setup-SSH-Authorization

But after docker container restart /var/www folder erased.
I add symlink  and .ssh folder can stored in /var/local/webvirtmgr
